### PR TITLE
fix(scan): rebalance ipc concurrency and fallback semantics

### DIFF
--- a/ContextMenuProfiler.UI/Core/BenchmarkService.cs
+++ b/ContextMenuProfiler.UI/Core/BenchmarkService.cs
@@ -56,6 +56,9 @@ namespace ContextMenuProfiler.UI.Core
 
     public class BenchmarkService
     {
+        private static readonly bool SkipKnownUnstableHandlers =
+            string.Equals(Environment.GetEnvironmentVariable("CMP_SKIP_UNSTABLE_HANDLERS"), "1", StringComparison.OrdinalIgnoreCase);
+
         private static readonly string[] KnownUnstableHandlerTokens =
         {
             "PintoStartScreen",
@@ -185,7 +188,7 @@ namespace ContextMenuProfiler.UI.Core
         {
             if (!result.Clsid.HasValue) return;
 
-            if (IsKnownUnstableHandler(result))
+            if (SkipKnownUnstableHandlers && IsKnownUnstableHandler(result))
             {
                 result.Status = "Skipped (Known Unstable)";
                 result.DetailedStatus = "Skipped Hook invocation for a known unstable system handler to avoid scan-wide IPC stalls.";
@@ -244,17 +247,25 @@ namespace ContextMenuProfiler.UI.Core
             }
             else if (hookData != null && !hookData.success)
             {
-                result.Status = "Load Error";
-                result.DetailedStatus = $"The Hook service failed to load this extension. Error: {hookData.error ?? "Unknown Error"}";
+                if (!string.IsNullOrEmpty(hookData.error) && hookData.error.Contains("Timeout", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Status = "IPC Timeout";
+                    result.DetailedStatus = $"Hook service timed out while probing this extension. Error: {hookData.error}";
+                }
+                else
+                {
+                    result.Status = "Load Error";
+                    result.DetailedStatus = $"The Hook service failed to load this extension. Error: {hookData.error ?? "Unknown Error"}";
+                }
             }
             else if (hookData == null)
             {
                 if (result.Status != "Load Error" && result.Status != "Orphaned / Missing DLL")
                 {
-                    if (string.Equals(result.Type, "UWP", StringComparison.OrdinalIgnoreCase))
+                    if (hookCall.roundtrip_ms >= 1900)
                     {
-                        result.Status = "Unsupported (UWP)";
-                        result.DetailedStatus = "This UWP/packaged extension could not be benchmarked via current Hook path on this system.";
+                        result.Status = "IPC Timeout";
+                        result.DetailedStatus = "Hook service response timed out for this extension. Data is based on registry scan only.";
                     }
                     else
                     {

--- a/ContextMenuProfiler.UI/Core/HookIpcClient.cs
+++ b/ContextMenuProfiler.UI/Core/HookIpcClient.cs
@@ -37,10 +37,9 @@ namespace ContextMenuProfiler.UI.Core
     public static class HookIpcClient
     {
         private const string PipeName = "ContextMenuProfilerHook";
-        private const int LockAcquireTimeoutMs = 5000;
-        private const int ConnectTimeoutMs = 500;
-        private const int RoundTripTimeoutMs = 3500;
-        internal static readonly SemaphoreSlim IpcLock = new SemaphoreSlim(1, 1);
+        private const int ConnectTimeoutMs = 1200;
+        private const int RoundTripTimeoutMs = 2000;
+        internal static readonly SemaphoreSlim IpcLock = new SemaphoreSlim(3, 3);
 
         public static async Task<HookCallResult> GetHookDataAsync(string clsid, string? contextPath = null, string? dllHint = null)
         {
@@ -61,18 +60,10 @@ namespace ContextMenuProfiler.UI.Core
                     try
                     {
                         var swLock = Stopwatch.StartNew();
-                        hasLock = await IpcLock.WaitAsync(LockAcquireTimeoutMs);
+                        await IpcLock.WaitAsync();
+                        hasLock = true;
                         swLock.Stop();
                         result.lock_wait_ms += Math.Max(0, (long)swLock.Elapsed.TotalMilliseconds);
-                        if (!hasLock)
-                        {
-                            if (attempt == 0)
-                            {
-                                await Task.Delay(150);
-                                continue;
-                            }
-                            return result;
-                        }
 
                         using (var client = new NamedPipeClientStream(".", PipeName, PipeDirection.InOut, PipeOptions.Asynchronous))
                         {
@@ -88,7 +79,7 @@ namespace ContextMenuProfiler.UI.Core
                                 Debug.WriteLine($"[IPC DIAG] Connection Failed: {ex.Message}");
                                 if (attempt == 0)
                                 {
-                                    await Task.Delay(120);
+                                    await Task.Delay(80);
                                     continue;
                                 }
                                 return result;
@@ -97,24 +88,26 @@ namespace ContextMenuProfiler.UI.Core
                             result.connect_ms += Math.Max(0, (long)swConnect.Elapsed.TotalMilliseconds);
 
                             var swRoundTrip = Stopwatch.StartNew();
+                            using var roundTripCts = new CancellationTokenSource(RoundTripTimeoutMs);
                             // Format: "CLSID|Path[|DllHint]"
                             string requestStr = string.IsNullOrEmpty(dllHint) ? $"{clsid}|{path}" : $"{clsid}|{path}|{dllHint}";
                             byte[] request = Encoding.UTF8.GetBytes(requestStr);
-                            await client.WriteAsync(request, 0, request.Length);
+                            await client.WriteAsync(request, 0, request.Length, roundTripCts.Token);
+                            await client.FlushAsync(roundTripCts.Token);
 
                             byte[] responseBuf = new byte[65536];
                             int read;
                             try
                             {
-                                read = await client.ReadAsync(responseBuf, 0, responseBuf.Length).WaitAsync(TimeSpan.FromMilliseconds(RoundTripTimeoutMs));
+                                read = await client.ReadAsync(responseBuf, 0, responseBuf.Length, roundTripCts.Token);
                             }
-                            catch (TimeoutException)
+                            catch (OperationCanceledException)
                             {
                                 swRoundTrip.Stop();
                                 result.roundtrip_ms += Math.Max(0, (long)swRoundTrip.Elapsed.TotalMilliseconds);
                                 if (attempt == 0)
                                 {
-                                    await Task.Delay(120);
+                                    await Task.Delay(80);
                                     continue;
                                 }
                                 return result;
@@ -126,7 +119,7 @@ namespace ContextMenuProfiler.UI.Core
                                 result.roundtrip_ms += Math.Max(0, (long)swRoundTrip.Elapsed.TotalMilliseconds);
                                 if (attempt == 0)
                                 {
-                                    await Task.Delay(120);
+                                    await Task.Delay(80);
                                     continue;
                                 }
                                 return result;
@@ -150,7 +143,7 @@ namespace ContextMenuProfiler.UI.Core
                                 result.roundtrip_ms += Math.Max(0, (long)swRoundTrip.Elapsed.TotalMilliseconds);
                                 if (attempt == 0)
                                 {
-                                    await Task.Delay(120);
+                                    await Task.Delay(80);
                                     continue;
                                 }
                                 return result;
@@ -161,7 +154,7 @@ namespace ContextMenuProfiler.UI.Core
                                 result.roundtrip_ms += Math.Max(0, (long)swRoundTrip.Elapsed.TotalMilliseconds);
                                 if (attempt == 0)
                                 {
-                                    await Task.Delay(120);
+                                    await Task.Delay(80);
                                     continue;
                                 }
                                 return result;
@@ -173,7 +166,7 @@ namespace ContextMenuProfiler.UI.Core
                         Debug.WriteLine($"[IPC DIAG] Critical Error: {ex.Message}");
                         if (attempt == 0)
                         {
-                            await Task.Delay(120);
+                            await Task.Delay(80);
                             continue;
                         }
                         return result;


### PR DESCRIPTION
## 变更摘要
- 

## 主要改动
- IPC 并发改为 3，调整超时时间
- 恢复 IPC Timeout 判定语义
- 将已知不稳定处理器跳过改为环境变量开关（默认关闭）

## 验证
- [x] 本地构建通过
- [x] 关键场景手测通过
- [x] 未新增警告或已说明

## 检查清单
- [x] 仅包含本 PR 相关改动
- [ ] 文案已本地化（如涉及 UI）
- [x] 提交信息清晰
